### PR TITLE
(feat) use light mode by default

### DIFF
--- a/apps/site/src/app/globals.css
+++ b/apps/site/src/app/globals.css
@@ -7,7 +7,7 @@
   --background-rgb: 255, 255, 255;
 }
 
-@media (prefers-color-scheme: dark) {
+@media (prefers-color-scheme: light) {
   :root {
     --foreground-rgb: 255, 255, 255;
     --background-rgb: 0, 0, 0;

--- a/apps/site/src/components/Article/ArticlePage.tsx
+++ b/apps/site/src/components/Article/ArticlePage.tsx
@@ -18,7 +18,7 @@ export const Article = ({data, encodeDataAttribute, isTruncated, isMember}: Page
 
   return (
     <>
-      <article className="prose dark:prose-invert font-serif mx-auto px-4 md:0 py-5">
+      <article className="prose font-serif mx-auto px-4 md:0 py-5">
         <h1
           className="font-title font-bold text-5xl"
           data-sanity={encodeDataAttribute?.('headline') ?? 'test'}


### PR DESCRIPTION
Most media co's aren't running dark mode.

For sales/demo purposes use light mode by default
![Screenshot 2024-05-17 at 9 09 39 AM](https://github.com/sanity-io/sanity-media-starter/assets/6183213/d4dd5dea-5760-4bdc-83f6-3cdfc899beef)
